### PR TITLE
메인 화면 카테고리 태그 추가, 시간 표현 방식 변경

### DIFF
--- a/components/main-page/Card.vue
+++ b/components/main-page/Card.vue
@@ -64,10 +64,7 @@
               </div>
             </div>
             <div class="card-bottom">
-              <div
-                v-if="category === 'mypostings' || category === 'bookmark'"
-                class="category-name"
-              >
+              <div class="category-name">
                 {{ post.categoryName }}
               </div>
               <div :class="'item created-day'">

--- a/plugins/mixins/common.js
+++ b/plugins/mixins/common.js
@@ -205,22 +205,20 @@ const common = {
 
     cmn_getPassedDay(createdDt) {
       const today = new Date()
-      const end = new Date(createdDt.replaceAll('-', '/'))
+      const createdDate = new Date(createdDt.replaceAll('-', '/'))
 
-      const diff = Math.floor(
-        ((end.getTime() - today.getTime()) / (1000 * 3600 * 24)) * -1
-      )
+      const minutesDiff = (today.getTime() - createdDate.getTime()) / (1000 * 60)
+      const day = {
+        "month": createdDate.getMonth().toString().padStart(2, '0'),
+        "date": createdDate.getDate().toString().padStart(2, '0'),
+        "hour": createdDate.getHours().toString().padStart(2, '0'),
+        "minute": createdDate.getMinutes().toString().padStart(2, '0')
+      }
 
-      if (diff === 0) {
-        return '오늘'
-      } else if (diff === 1) {
-        return '어제'
-      } else if (diff === 2) {
-        return '2일전'
-      } else if (diff === 3) {
-        return '3일전'
+      if (minutesDiff >= 60){
+        return `${day.month}/${day.date} ${day.hour}:${day.minute}`
       } else {
-        return createdDt.substring(0, 10)
+        return `${Math.ceil(minutesDiff)}분전`
       }
     },
 


### PR DESCRIPTION
작업내용은 다음과 같습니다.

1. 메인 화면에서도 서브 카테고리 태그 표시
2. 시간 표시 방식 변경
    - AS-IS : 공고 생성일로부터 3일까지 `0일전` 으로 표시, 그외는 `연도-날짜`
    - TO-BE : 공고 생성일로부터 60분까지 `0분전` 으로 표시, 그외는 `날짜-시간` 